### PR TITLE
feat(hid): add slow parameter to type_text()

### DIFF
--- a/src/aiopikvm/resources/hid.py
+++ b/src/aiopikvm/resources/hid.py
@@ -58,16 +58,19 @@ class HIDResource(BaseResource):
         result: dict[str, Any] = await self._get("/api/hid/keymaps")
         return result
 
-    async def type_text(self, text: str, *, limit: int = 0) -> None:
+    async def type_text(self, text: str, *, limit: int = 0, slow: bool = False) -> None:
         """Type text via HID keyboard.
 
         Args:
             text: Text string to type.
             limit: Maximum characters per request (``0`` = unlimited).
+            slow: Enable server-side per-character delays for reliable input.
         """
         params: dict[str, int] = {}
         if limit > 0:
             params["limit"] = limit
+        if slow:
+            params["slow"] = 1
         await self._post(
             "/api/hid/print",
             content=text.encode(),

--- a/tests/test_hid.py
+++ b/tests/test_hid.py
@@ -128,6 +128,15 @@ async def test_set_params_partial(mock_api: respx.MockRouter, client: PiKVM) -> 
     assert "mouse_output" not in str(request.url)
 
 
+async def test_type_text_with_slow(mock_api: respx.MockRouter, client: PiKVM) -> None:
+    mock_api.post("/api/hid/print").mock(
+        return_value=httpx.Response(200, json={"ok": True, "result": {}})
+    )
+    await client.hid.type_text("hello", slow=True)
+    request = mock_api.calls[-1].request
+    assert "slow=1" in str(request.url)
+
+
 async def test_type_text_with_limit(mock_api: respx.MockRouter, client: PiKVM) -> None:
     mock_api.post("/api/hid/print").mock(
         return_value=httpx.Response(200, json={"ok": True, "result": {}})


### PR DESCRIPTION
## Summary
- Added `slow: bool = False` parameter to `HIDResource.type_text()`
- When enabled, passes `slow=1` query parameter to `POST /api/hid/print` for server-side per-character delays
- Some target machines drop keystrokes during fast input — `slow` mode solves this

Closes #1

## Test plan
- [x] Unit test `test_type_text_with_slow` verifies `slow=1` is passed in query params
- [x] All 16 HID tests pass
- [x] ruff, mypy checks pass