### PR TITLE
fix(hid): use plural 'keys' query param in send_shortcut (#19)

### DIFF
--- a/src/aiopikvm/resources/hid.py
+++ b/src/aiopikvm/resources/hid.py
@@ -101,9 +101,12 @@ class HIDResource(BaseResource):
         params: dict[str, Any] = {}
         if wait > 0:
             params["wait"] = wait
+        # The PiKVM endpoint expects the multi-value param `keys`, not `key`;
+        # sending `key` returns ``HTTP 400 ValidatorError`` because the
+        # required `keys` argument is missing.
         await self._post(
             "/api/hid/events/send_shortcut",
-            params={**params, "key": list(keys)},
+            params={**params, "keys": list(keys)},
         )
 
     async def send_mouse_button(

--- a/tests/test_hid.py
+++ b/tests/test_hid.py
@@ -50,8 +50,9 @@ async def test_send_shortcut(mock_api: respx.MockRouter, client: PiKVM) -> None:
     await client.hid.send_shortcut("ControlLeft", "KeyC")
     request = mock_api.calls[-1].request
     url_params = str(request.url)
-    assert "key=ControlLeft" in url_params
-    assert "key=KeyC" in url_params
+    # PiKVM expects the plural `keys` query param.
+    assert "keys=ControlLeft" in url_params
+    assert "keys=KeyC" in url_params
 
 
 async def test_send_mouse_move(mock_api: respx.MockRouter, client: PiKVM) -> None:


### PR DESCRIPTION
Fixes #19. `HIDResource.send_shortcut` was sending the multi-value query parameter as `key=...&key=...`, but the PiKVM endpoint `/api/hid/events/send_shortcut` validates `keys` (plural) and rejected the request with:

```
HTTP 400 ValidatorError: 'None argument is not a valid string list'
```

The single-key endpoint (`send_key`) is unaffected — it really does take a singular `key` query parameter.

## Change

`src/aiopikvm/resources/hid.py:106` — `{"key": list(keys)}` → `{"keys": list(keys)}`. Updated the corresponding `tests/test_hid.py::test_send_shortcut` assertion from `key=ControlLeft`/`key=KeyC` to `keys=ControlLeft`/`keys=KeyC`.

## Test plan

- [x] `pytest tests/test_hid.py` — 16/16 passed
- [x] Plural `keys` matches what the issue reporter verified against a real PiKVM via direct curl
EOF