### PR TITLE
chore(release): 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.2.1] — 2026-05-05
+
+### Fixed
+
+- `HIDResource.send_shortcut` was sending the multi-value query parameter as
+  `key=...` (singular); kvmd validates `keys` (plural) and rejected the
+  request with HTTP 400 (#19).
+- `StreamerState` model rewritten to match the actual `/api/streamer`
+  response: top-level `features` / `limits` / `params` / `snapshot` /
+  `streamer` (the latter is `null` when no stream clients are connected).
+  The previous top-level `enabled` and `source` fields never existed in the
+  API and `get_state()` always raised `pydantic.ValidationError` (#18).
+- `StreamerResource.ocr()` was calling the wrong endpoint
+  (`/api/streamer/ocr`, which returns capability metadata) and parsing
+  capability JSON as a string. It now sends
+  `GET /api/streamer/snapshot?ocr=1` and returns plain text. Added a
+  `langs` parameter (comma-separated by kvmd) and a 30 s default per-call
+  timeout — Tesseract on the Pi takes 10–20 s for full-screen OCR,
+  exceeding the client default (#21).
+
+### Added
+
+- `StreamerResource.get_ocr_info()` and `OCRInfo` / `OCRLangs` models for
+  `GET /api/streamer/ocr` capability metadata (replaces the
+  always-broken `OCRResult`).
+- `allow_offline` parameter on `StreamerResource.snapshot()` and
+  `StreamerResource.ocr()`. When the video source is offline (host asleep,
+  HDMI unplugged) but the streamer process is still running, kvmd returns
+  HTTP 503 by default; with `allow_offline=True` it returns a
+  "NO LIVE VIDEO" placeholder JPEG (or its OCR'd text). The flag has no
+  effect when the streamer process is fully stopped — that is a kvmd
+  lifecycle limitation (#22).
+- Optional `timeout` argument on `PiKVM.request()` and
+  `BaseResource._get_raw()` for per-call timeout overrides.
+
+### Changed
+
+- New typed submodels for streamer state: `Streamer`, `StreamerEncoder`,
+  `StreamerH264`, `StreamerSinkInfo`, `StreamerSinks`, `StreamerStream`,
+  `StreamerLimits`, `StreamerLimitRange`, `StreamerFeatures`,
+  `StreamerParams`, `StreamerSnapshot`. `StreamerSource` now exposes
+  `captured_fps` and `desired_fps` in addition to `online` and
+  `resolution`.
+
+### Removed
+
+- `OCRResult` model — replaced by `OCRInfo` (capability metadata) and a
+  plain `str` return from `ocr()`. The old model never matched any real
+  response.
+
 ## [0.1.1] — 2026-02-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ src/aiopikvm/
 │   ├── hid.py               # HIDMouse, HIDKeyboard, HIDState, HIDKeymap
 │   ├── msd.py               # MSDDrive, MSDStorage, MSDState
 │   ├── gpio.py              # GPIOChannel, GPIOInput, GPIOState
-│   ├── streamer.py          # Resolution, StreamerSource, StreamerState, OCRResult
+│   ├── streamer.py          # StreamerState, Streamer (+ submodels), StreamerSource, Resolution, OCRInfo, OCRLangs
 │   └── switch.py            # SwitchPort, SwitchState, EDID
 └── resources/
     ├── __init__.py           # Module docstring only

--- a/docs/guide/streamer.md
+++ b/docs/guide/streamer.md
@@ -4,12 +4,20 @@ The Streamer resource captures screenshots and performs OCR (optical character r
 
 ## Get state
 
+`StreamerState.streamer` is `None` when no clients are subscribed to the
+stream — kvmd shuts the streamer process down to save resources. When it
+is running, `streamer.source.online` indicates whether a video signal is
+present (host awake, HDMI plugged).
+
 ```python
 state = await kvm.streamer.get_state()
-print(f"Enabled: {state.enabled}")
-print(f"Source online: {state.source.online}")
-if state.source.resolution:
-    print(f"Resolution: {state.source.resolution.width}x{state.source.resolution.height}")
+if state.streamer is None:
+    print("Streamer is not running (no active stream clients)")
+elif not state.streamer.source.online:
+    print("Streamer running, but no video signal")
+else:
+    res = state.streamer.source.resolution
+    print(f"Online at {res.width}x{res.height}, {state.streamer.h264.fps} fps")
 ```
 
 ## Take a screenshot
@@ -19,10 +27,20 @@ Returns raw JPEG image bytes:
 ```python
 jpeg_bytes = await kvm.streamer.snapshot()
 
-# Save to file
 with open("screenshot.jpeg", "wb") as f:
     f.write(jpeg_bytes)
 ```
+
+By default `snapshot()` returns HTTP 503 if the video source is offline.
+Pass `allow_offline=True` to receive a "NO LIVE VIDEO" placeholder
+instead:
+
+```python
+jpeg_bytes = await kvm.streamer.snapshot(allow_offline=True)
+```
+
+The flag has no effect when the streamer process is fully stopped — that
+case still raises `APIError(503)`.
 
 ## OCR
 
@@ -31,6 +49,24 @@ Read text from the current screen:
 ```python
 text = await kvm.streamer.ocr()
 print(text)
+
+# Multi-language recognition
+text = await kvm.streamer.ocr(langs=["eng", "rus"])
+
+# Read text from the placeholder when the source is offline
+text = await kvm.streamer.ocr(allow_offline=True)
+```
+
+`ocr()` uses a 30 s default timeout because Tesseract on the Pi is slow
+(10–20 s for full-screen recognition). Override via the `timeout`
+argument if needed.
+
+To inspect installed OCR languages:
+
+```python
+info = await kvm.streamer.get_ocr_info()
+print(info.langs.available)  # e.g. ["eng", "osd", "rus"]
+print(info.langs.default)    # e.g. ["eng"]
 ```
 
 !!! note
@@ -50,18 +86,15 @@ from aiopikvm import PiKVM
 
 async def main():
     async with PiKVM("https://pikvm.local", user="admin", passwd="admin") as kvm:
-        # Check if source is online
         state = await kvm.streamer.get_state()
-        if not state.source.online:
+        if state.streamer is None or not state.streamer.source.online:
             print("Video source is offline")
             return
 
-        # Take a screenshot
         jpeg = await kvm.streamer.snapshot()
         with open("screen.jpeg", "wb") as f:
             f.write(jpeg)
 
-        # Read text from screen
         text = await kvm.streamer.ocr()
         if "login" in text.lower():
             print("Login screen detected")

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -64,6 +64,10 @@ All response models inherit from a base class with `extra="allow"` for forward-c
     options:
       show_bases: false
 
+::: aiopikvm.Streamer
+    options:
+      show_bases: false
+
 ::: aiopikvm.StreamerSource
     options:
       show_bases: false
@@ -72,7 +76,11 @@ All response models inherit from a base class with `extra="allow"` for forward-c
     options:
       show_bases: false
 
-::: aiopikvm.OCRResult
+::: aiopikvm.OCRInfo
+    options:
+      show_bases: false
+
+::: aiopikvm.OCRLangs
     options:
       show_bases: false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiopikvm"
-version = "0.2.0"
+version = "0.2.1"
 description = "Async Python client for PiKVM API"
 readme = "README.md"
 license = "MIT"

--- a/src/aiopikvm/__init__.py
+++ b/src/aiopikvm/__init__.py
@@ -34,7 +34,7 @@ from aiopikvm.models.streamer import (
 )
 from aiopikvm.models.switch import EDID, SwitchPort, SwitchState
 
-__version__ = "0.1.1"
+__version__ = "0.2.1"
 
 __all__ = [
     "EDID",

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.13"
 
 [[package]]
 name = "aiopikvm"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Release PR for **0.2.1**.

- Bump version to 0.2.1 in `pyproject.toml` and `src/aiopikvm/__init__.py` (the latter was still at 0.1.1 from a drift in the 0.2.0 release).
- Update `uv.lock` to reflect the new version.
- Add 0.2.1 CHANGELOG entry — fixes #18, #19, #21, #22; new `allow_offline` parameter; new `get_ocr_info()` and `OCRInfo` model; per-call `timeout` override on `PiKVM.request`.
- Update streamer docs/guide and reference for the new API (replaces removed `OCRResult` and updates code examples for the new `StreamerState` shape — also restores `docs.yml` which broke on main after #23).

## Test plan

- [x] `pytest` — 142/142 passed
- [x] `ruff check`, `ruff format --check`, `mypy src/` — clean
- [x] `mkdocs build --strict` — succeeds locally (the production blocker — missing `OCRResult` reference — is fixed)
- [x] `uv sync` regenerates `uv.lock` cleanly

## Release flow after merge

1. Merge this PR.
2. Tag and push: `git tag v0.2.1 && git push origin v0.2.1`.
3. `release.yml` runs full CI, builds, publishes to PyPI via trusted publisher, creates a GitHub release with auto-generated notes.
4. `docs.yml` rebuilds and deploys docs (now green again).

## Note on CHANGELOG

The 0.2.0 entry was never written — only 0.1.1 is in `CHANGELOG.md`. I left that gap untouched in this PR (separate concern). Worth backfilling later or rolling into the release notes for 0.2.0 retroactively.